### PR TITLE
Update to 4.4.4

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,11 @@ if [ "$(uname)" == "Darwin" ]; then
     export DYLD_LIBRARY_PATH=${PREFIX}/lib
 fi
 
-CPPFLAGS=-I$PREFIX/include LDFLAGS=-L$PREFIX/lib ./configure --prefix=$PREFIX
+export CPPFLAGS="-I$PREFIX/include $CPPFLAGS"
+export LDFLAGS="-L$PREFIX/lib $LDFLAGS"
+export CFLAGS="-fPIC $CFLAGS"
+
+./configure --prefix=$PREFIX
 
 make
 make check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,29 @@
+{% set version = "4.4.4" %}
+
 package:
     name: netcdf-fortran
-    version: 4.4.3
+    version: 4.4.4
 
 source:
-    git_url: https://github.com/Unidata/netcdf-fortran
-    git_tag: v4.4.3
+    fn: netcdf-fortran-{{ version }}.tar.gz
+    url: https://github.com/Unidata/netcdf-fortran/archive/v{{ version }}.tar.gz
+    sha256: 44b1986c427989604df9925dcdbf6c1a977e4ecbde6dd459114bca20bf5e9e67
 
 build:
-    number: 2
+    number: 0
     skip: True  # [win]
 
 requirements:
     build:
-        - libnetcdf 4.3*
+        - libnetcdf 4.4.*
         - krb5
         - gcc
+        - isl 0.12.*
     run:
-        - libnetcdf 4.3*
+        - libnetcdf 4.4.*
         - krb5
         - libgcc
+        - isl 0.12.*
 
 test:
     commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,8 +26,10 @@ requirements:
         - isl 0.12.*
 
 test:
+    requires:
+        - python {{ environ['PY_VER'] + '*' }}  # [win]
     commands:
-        - nf-config --all
+        #- nf-config --all  # FIXME: no nf-config for cmake
         - conda inspect linkages -n _test netcdf-fortran  # [linux]
 
 about:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,18 @@
+# Load the libraries using ctypes.
+import os
+import sys
+import ctypes
+
+platform = sys.platform
+
+if platform.startswith('linux'):
+    path = os.path.join(sys.prefix, 'lib', 'libnetcdff.so')
+    lib = ctypes.CDLL(path)
+elif platform == 'darwin':
+    path = os.path.join(sys.prefix, 'lib', 'libnetcdff.dylib')
+    lib = ctypes.CDLL(path)
+elif platform == 'win32':
+    path = os.path.join(sys.prefix, 'Library', 'bin', 'libnetcdff.dll')
+    lib = ctypes.CDLL(path)
+else:
+    raise ValueError('Unrecognized platform: {}'.format(platform))


### PR DESCRIPTION
## 4.4.4 Released May 13, 2016
- Corrected an issue where cmake-based builds specifying `USE_LOGGING` were not seeing expected behavior.  The issue was reported, and subsequently fixed, by Neil Carlson at Los Alamos Nat'l Laboratory. See [Github Pull Request #44](https://github.com/Unidata/netcdf-fortran/pull/44) for more information.
- Integrated improvements provided by Richard Weed.  For a _complete_ list of modifications, see the file `docs/netcdf_fortran_4.4.2dev_notes_RW.pdf`.  **It is highly detailed and worth reading!**
  
  The highlights of the improvements are as follows:
  - Explicit dependencies on `NC_MAX_DIM` constant for arrays has been removed and replaced with dynamically-allocated arrays.
  - Support for `nc_open_mem()` in the C library, allowing for the creation of "in memory" files.
  - General clean up.
