### PR TITLE
Update to 4.4.4

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,10 +1,20 @@
 #!/bin/bash
 
+if [[ $(uname) == Darwin ]]; then
+  export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
+elif [[ $(uname) == Linux ]]; then
+  export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
+fi
+
+export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
+export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
+
 # Build static.
 cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
       -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
       -D BUILD_SHARED_LIBS=OFF \
       $SRC_DIR
+
 make
 ctest
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-# See http://www.unidata.ucar.edu/support/help/MailArchives/netcdf/msg11939.html
-if [ "$(uname)" == "Darwin" ]; then
-    export DYLD_LIBRARY_PATH=${PREFIX}/lib
-fi
-
-CPPFLAGS=-I$PREFIX/include LDFLAGS=-L$PREFIX/lib ./configure --prefix=$PREFIX
-
+# Build static.
+cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
+      -D BUILD_SHARED_LIBS=OFF \
+      $SRC_DIR
 make
-make check
+ctest
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,9 +10,24 @@ export LDFLAGS="$LDFLAGS -L$PREFIX/lib -Wl,-rpath,$PREFIX/lib"
 export CFLAGS="$CFLAGS -fPIC -I$PREFIX/include"
 
 # Build static.
+mkdir build_static && cd build_static
 cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
       -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
       -D BUILD_SHARED_LIBS=OFF \
+      $SRC_DIR
+
+make
+# ctest  # Run only for the shared lib build to save time.
+make install
+
+make clean
+
+cd ..
+mkdir build_shared && cd build_shared
+# Build shared.
+cmake -D CMAKE_INSTALL_PREFIX=$PREFIX \
+      -D CMAKE_INSTALL_LIBDIR:PATH=$PREFIX/lib \
+      -D BUILD_SHARED_LIBS=ON \
       $SRC_DIR
 
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,10 @@ requirements:
         - isl 0.12.*
 
 test:
+    requires:
+        - python {{ environ['PY_VER'] + '*' }}  # [win]
     commands:
-        - nf-config --all
+        #- nf-config --all  # FIXME: no nf-config for cmake
         - conda inspect linkages -n _test netcdf-fortran  # [linux]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ source:
     fn: netcdf-fortran-{{ version }}.tar.gz
     url: https://github.com/Unidata/netcdf-fortran/archive/v{{ version }}.tar.gz
     sha256: 44b1986c427989604df9925dcdbf6c1a977e4ecbde6dd459114bca20bf5e9e67
+    patches:
+        - no_clang.patch  # [osx]
 
 build:
     number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,24 +1,31 @@
+{% set version = "4.4.4" %}
+
 package:
     name: netcdf-fortran
-    version: 4.4.3
+    version: {{ version }}
 
 source:
-    git_url: https://github.com/Unidata/netcdf-fortran
-    git_tag: v4.4.3
+    fn: netcdf-fortran-{{ version }}.tar.gz
+    url: https://github.com/Unidata/netcdf-fortran/archive/v{{ version }}.tar.gz
+    sha256: 44b1986c427989604df9925dcdbf6c1a977e4ecbde6dd459114bca20bf5e9e67
 
 build:
-    number: 2
+    number: 0
     skip: True  # [win]
 
 requirements:
     build:
-        - libnetcdf 4.3*
+        - cmake
+        - libnetcdf 4.4.*
+        - pkg-config  # [unix]
         - krb5
         - gcc
+        - isl 0.12.*
     run:
-        - libnetcdf 4.3*
+        - libnetcdf 4.4.*
         - krb5
         - libgcc
+        - isl 0.12.*
 
 test:
     commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
         - python {{ environ['PY_VER'] + '*' }}  # [win]
     commands:
         #- nf-config --all  # FIXME: no nf-config for cmake
+        - test -f ${PREFIX}/lib/libnetcdf.a  # [unix]
         - conda inspect linkages -n _test netcdf-fortran  # [linux]
 
 about:

--- a/recipe/no_clang.patch
+++ b/recipe/no_clang.patch
@@ -1,0 +1,12 @@
+--- CMakeLists.txt	2016-05-13 18:17:37.000000000 -0300
++++ CMakeLists.txt	2016-06-20 09:51:58.276466121 -0300
+@@ -482,9 +482,6 @@
+ IF (UNIX AND ${CMAKE_SIZEOF_VOID_P} MATCHES "8")
+   ADD_DEFINITIONS(-DLONGLONG_IS_LONG)
+   # for easier debugging of cfortran.h
+-  IF (APPLE)
+-    SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fmacro-backtrace-limit=0")
+-  endif ()
+ ENDIF()
+ 
+ # Determine C/Fortran pointer compatibility.

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,0 +1,18 @@
+# Load the libraries using ctypes.
+import os
+import sys
+import ctypes
+
+platform = sys.platform
+
+if platform.startswith('linux'):
+    path = os.path.join(sys.prefix, 'lib', 'libnetcdff.so')
+    lib = ctypes.CDLL(path)
+elif platform == 'darwin':
+    path = os.path.join(sys.prefix, 'lib', 'libnetcdff.dylib')
+    lib = ctypes.CDLL(path)
+elif platform == 'win32':
+    path = os.path.join(sys.prefix, 'Library', 'bin', 'libnetcdff.dll')
+    lib = ctypes.CDLL(path)
+else:
+    raise ValueError('Unrecognized platform: {}'.format(platform))


### PR DESCRIPTION
## 4.4.4 Released May 13, 2016
- Corrected an issue where cmake-based builds specifying `USE_LOGGING` were not seeing expected behavior.  The issue was reported, and subsequently fixed, by Neil Carlson at Los Alamos Nat'l Laboratory. See [Github Pull Request #44](https://github.com/Unidata/netcdf-fortran/pull/44) for more information.
- Integrated improvements provided by Richard Weed.  For a _complete_ list of modifications, see the file `docs/netcdf_fortran_4.4.2dev_notes_RW.pdf`.  **It is highly detailed and worth reading!**
  
  The highlights of the improvements are as follows:
  - Explicit dependencies on `NC_MAX_DIM` constant for arrays has been removed and replaced with dynamically-allocated arrays.
  - Support for `nc_open_mem()` in the C library, allowing for the creation of "in memory" files.
  - General clean up.

PS: Trying to build `netcdf-fortran` with `cmake`.
