### PR TITLE
version with hdf 1.10.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,19 +11,19 @@ source:
     - no_clang.patch  # [osx]
 
 build:
-  number: 5
+  number: 6
   skip: True  # [win]
 
 requirements:
   build:
     - cmake
     - libnetcdf 4.4.*
-    - hdf5 1.8.18|1.8.18.*
+    - hdf5 1.10.1
     - pkg-config  # [not win]
     - gcc  # [not win]
   run:
     - libnetcdf 4.4.*
-    - hdf5 1.8.18|1.8.18.*
+    - hdf5 1.10.1
     - libgcc  # [linux]
     - libgfortran  # [osx]
 


### PR DESCRIPTION
Restore the `hdf5 1.10.1` pin.